### PR TITLE
Fixed issue #11 - server_names on new lines missed

### DIFF
--- a/nginxctl.py
+++ b/nginxctl.py
@@ -387,7 +387,7 @@ Attempt to query /server-status returned an error
             ip_port = []
             server_name_found = False
             server_dict = {}
-            stored = ''
+            store_multiline = ''
             for line_num, li in enumerate(vhost_data, start=server_block[0]):
                 l = vhost_data[line_num]
                 if line_num >= server_block[1]:
@@ -403,13 +403,20 @@ Attempt to query /server-status returned an error
                     continue
                 l = l.split('#')[0]
 
+                # Continue recording directive information if the line
+                # doesn't end with ';' (eg. server_name's listed on new lines)
                 if not l.strip().endswith(';'):
                     if line_num != server_block[0]:
-                        stored += l.strip() + ' '
+                        store_multiline += l.strip() + ' '
                     continue
-                l = stored + l
+
+                # Once the directive has been "closed" (ends with ';') and
+                # multi_line_buffer is being used, proceed as if all information
+                # was on a single line and reset buffer.
+                if store_multiline:
+                    l = store_multiline + l
+                    store_multiline = ''
                 l = l.strip().strip(';')
-                stored = ''
 
                 if l.startswith('server_name') and server_name_found:
                     alias += l.split()[1:]

--- a/nginxctl.py
+++ b/nginxctl.py
@@ -387,6 +387,7 @@ Attempt to query /server-status returned an error
             ip_port = []
             server_name_found = False
             server_dict = {}
+            stored = ''
             for line_num, li in enumerate(vhost_data, start=server_block[0]):
                 l = vhost_data[line_num]
                 if line_num >= server_block[1]:
@@ -401,7 +402,14 @@ Attempt to query /server-status returned an error
                 if l.startswith('#'):
                     continue
                 l = l.split('#')[0]
+
+                if not l.strip().endswith(';'):
+                    if line_num != server_block[0]:
+                        stored += l.strip() + ' '
+                    continue
+                l = stored + l
                 l = l.strip().strip(';')
+                stored = ''
 
                 if l.startswith('server_name') and server_name_found:
                     alias += l.split()[1:]

--- a/test_nginxctl.py
+++ b/test_nginxctl.py
@@ -24,7 +24,9 @@ class nginxCtlTests(unittest.TestCase):
         test_vhost_content = "server {\n\
                                     listen 8080;\n\
                                     listen [::]:80;\n\
-                                    server_name example.com;\n\
+                                    server_name example.com\n\
+                                            www.example.com\n\
+                                            blog.example.com;\n\
                                     root /var/www/html;\n\
                                     index index.html;\n\
                                     client_max_body_size 4G;\n\
@@ -47,8 +49,10 @@ class nginxCtlTests(unittest.TestCase):
         n = nginxctl.nginxCtl()
         vhost_info = n._get_vhosts_info(vhost_file.name)
         servername = vhost_info[0]['servername']
+        serveralias = vhost_info[0]['alias']
         ip_port = vhost_info[0]['ip_port']
         self.assertEqual('example.com', servername)
+        self.assertEqual(['www.example.com', 'blog.example.com'], serveralias)
         self.assertEqual(['8080', '[::]:80'], ip_port)
         vhost_file.close()
 


### PR DESCRIPTION
This PR fixes issue #11, small code updated vs PR #8.
New line directives for server_name should now be listed in nginxctl ouput. 