### PR TITLE
Added default script option "list nginx vhosts" (-S)

### DIFF
--- a/nginxctl.py
+++ b/nginxctl.py
@@ -519,6 +519,6 @@ def main():
         else:
             usage()
     else:
-        usage()
+        n.get_vhosts()
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Script now runs `-S` (list nginx vhosts) as it's default option (if no arguments are parsed)